### PR TITLE
Refactor parameter persistence and add multi-symbol workflow

### DIFF
--- a/strategies/base.py
+++ b/strategies/base.py
@@ -36,7 +36,7 @@ class StrategyDefinition:
     name: str
     description: str = ""
     controls: Dict[str, Dict[str, Any]] = field(default_factory=dict)
-    ranges: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    range_controls: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     default_params: Dict[str, Any] = field(default_factory=dict)
     data_requirements: Dict[str, Any] = field(default_factory=dict)
     prepare_data: PrepareDataFn = field(default_factory=lambda: _identity_prepare)

--- a/strategies/ema_trend.py
+++ b/strategies/ema_trend.py
@@ -271,7 +271,7 @@ EMA_STRATEGY = StrategyDefinition(
             ),
         }
     ),
-    ranges={},
+    range_controls={},
     default_params=DEFAULT_PARAMS,
     data_requirements={
         "chart_overlays": [


### PR DESCRIPTION
## Summary
- route strategy parameter widgets through a per-strategy session state dictionary and add preset save/load helpers
- consume `StrategyDefinition.range_controls`, persist optimization runs per strategy, and update the strategy schema accordingly
- extend the data UI to support multi-symbol requirements and cache each dataset for downstream consumers

## Testing
- python -m compileall app.py strategies

------
https://chatgpt.com/codex/tasks/task_e_68e072b39404832580713781b8736bcc