### PR TITLE
Ensure strategy optimizations build on prepared data

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,6 +239,7 @@ def run_simple_backtest(
     params: dict,
     strategy: StrategyDefinition | None = None,
     df_sig: pd.DataFrame | None = None,
+    df_prepared: pd.DataFrame | None = None,
 ):
     from backtesting import Backtest
 
@@ -255,14 +256,15 @@ def run_simple_backtest(
     fee_percent = float(base_params.get("fee_percent", 0.0))
     slippage_percent = float(base_params.get("slippage_percent", 0.0))
 
+    prepared_df = df_prepared if df_prepared is not None else strategy.prepare_data(df, base_params)
     if df_sig is None:
-        df_sig = strategy.generate_signals(df, base_params)
+        df_sig = strategy.generate_signals(prepared_df, base_params)
 
     builder = strategy.build_simple_backtest_strategy
     if builder is None:
         raise ValueError(f"Strategy '{strategy.key}' does not provide a simple backtest builder.")
 
-    strat_cls = builder(df, df_sig, base_params)
+    strat_cls = builder(prepared_df, df_sig, base_params)
 
     risk_cfg = RiskEngineConfig.from_params(base_params.get("risk_config"))
     risk_engine_template = RiskEngine(risk_cfg)
@@ -378,7 +380,7 @@ def run_simple_backtest(
                     return None
             return super().sell(size=final_size, **kwargs)
 
-    df_bt = df[["Open", "High", "Low", "Close", "Volume"]].copy()
+    df_bt = prepared_df[["Open", "High", "Low", "Close", "Volume"]].copy()
     df_bt[["Open", "High", "Low", "Close"]] = df_bt[["Open", "High", "Low", "Close"]] * contract_size
 
     bt = Backtest(
@@ -424,6 +426,7 @@ def run_true_stop_backtest(
     params: dict,
     strategy: StrategyDefinition | None = None,
     df_sig: pd.DataFrame | None = None,
+    df_prepared: pd.DataFrame | None = None,
 ):
     import backtrader as bt
 
@@ -439,14 +442,15 @@ def run_true_stop_backtest(
     slippage_percent = float(base_params.get("slippage_percent", 0.0))
     initial_cash = float(base_params.get("initial_cash", 10_000.0))
 
+    prepared_df = df_prepared if df_prepared is not None else strategy.prepare_data(df, base_params)
     if df_sig is None:
-        df_sig = strategy.generate_signals(df, base_params)
+        df_sig = strategy.generate_signals(prepared_df, base_params)
 
     builder = strategy.build_true_stop_strategy
     if builder is None:
         raise ValueError(f"Strategy '{strategy.key}' does not provide a true stop builder.")
 
-    bt_strategy_cls = builder(df, df_sig, base_params)
+    bt_strategy_cls = builder(prepared_df, df_sig, base_params)
 
     risk_cfg = RiskEngineConfig.from_params(base_params.get("risk_config"))
     risk_engine_template = RiskEngine(risk_cfg)
@@ -545,7 +549,9 @@ def run_true_stop_backtest(
 
     timeframe = str(base_params.get("timeframe", "1h"))
     comp = 60 if timeframe == "1h" else (240 if timeframe == "4h" else 1440)
-    data_bt = bt.feeds.PandasData(dataname=df, timeframe=bt.TimeFrame.Minutes, compression=comp)
+    data_bt = bt.feeds.PandasData(
+        dataname=prepared_df, timeframe=bt.TimeFrame.Minutes, compression=comp
+    )
     cerebro.adddata(data_bt)
     cerebro.addsizer(RiskAwareCashSizer)
     cerebro.addstrategy(RiskManagedBTStrategy)
@@ -1238,9 +1244,21 @@ if mode == "Backtest":
 
         if run_bt:
             if engine == "Simple (backtesting.py)":
-                result = run_simple_backtest(df, base_params, strategy=active_strategy, df_sig=df_sig)
+                result = run_simple_backtest(
+                    df,
+                    base_params,
+                    strategy=active_strategy,
+                    df_sig=df_sig,
+                    df_prepared=prepared_df,
+                )
             else:
-                result = run_true_stop_backtest(df, base_params, strategy=active_strategy, df_sig=df_sig)
+                result = run_true_stop_backtest(
+                    df,
+                    base_params,
+                    strategy=active_strategy,
+                    df_sig=df_sig,
+                    df_prepared=prepared_df,
+                )
 
             metrics_series = pd.Series(result["metrics"])
             st.markdown("### Summary metrics")
@@ -1294,9 +1312,19 @@ if mode == "Backtest":
                     for k, v in zip(combos_keys, combo):
                         combo_params[k] = v
                     if engine == "Simple (backtesting.py)":
-                        result = run_simple_backtest(df, combo_params, strategy=active_strategy)
+                        result = run_simple_backtest(
+                            df,
+                            combo_params,
+                            strategy=active_strategy,
+                            df_prepared=None,
+                        )
                     else:
-                        result = run_true_stop_backtest(df, combo_params, strategy=active_strategy)
+                        result = run_true_stop_backtest(
+                            df,
+                            combo_params,
+                            strategy=active_strategy,
+                            df_prepared=None,
+                        )
 
                     metrics = result.get("metrics", {})
                     objective_value = metrics.get(objective_metric)


### PR DESCRIPTION
## Summary
- ensure simple and true-stop backtests always derive signals from each strategy's prepared dataset
- pass prepared data through the Streamlit backtest UI so single runs reuse cached preprocessing while optimizations recompute per parameter set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e083ed86108325a3ed7e2951fed6fd