### PR TITLE
Add multi-timeframe BTC strategies with risk controls

### DIFF
--- a/ai_trader_strats/README.md
+++ b/ai_trader_strats/README.md
@@ -1,0 +1,31 @@
+# AI Trader Strategies
+
+Strategy bundle providing a daily core trend booster and an hourly overlay for BTC/EUR.
+
+## Components
+
+- `DailyTrendBooster`: boosts exposure to 1.3× during confirmed breakouts and reverts to 0.3× otherwise while honouring hard risk locks.
+- `HourlyTrendOverlay`: adds up to 0.2× extra notional when intra-day momentum confirms the daily breakout and the overall leverage stays below 1.5×.
+- `RiskEngineAdapter`: synchronises the strategies with the platform risk engine enforcing drawdown and daily loss locks.
+- `rebalance_to_notional`: helper that targets a desired notional accounting for trading fees.
+- `MultiTimeframeOrchestrator`: command line entry point to wire feeds, broker and strategies together.
+
+## Usage
+
+```bash
+python -m ai_trader_strats.orchestrator \
+  --config-daily ai_trader_strats/configs/btc_eur_daily_trend_booster.json \
+  --data-daily /path/to/BTC_EUR_1d.csv \
+  --config-hourly ai_trader_strats/configs/btc_eur_hourly_overlay.json \
+  --data-hourly /path/to/BTC_EUR_1h.csv
+```
+
+Feeds must contain the columns `Timestamp, Open, High, Low, Close, Volume` (case-insensitive) sorted in ascending order. Timestamps are parsed as UTC and signals execute on the next bar.
+
+## Testing
+
+Run the suite with:
+
+```bash
+pytest ai_trader_strats/tests
+```

--- a/ai_trader_strats/__init__.py
+++ b/ai_trader_strats/__init__.py
@@ -1,0 +1,17 @@
+"""Strategy package for multi-timeframe BTC/EUR trading."""
+
+from .config_schemas import (
+    BoosterDailyConfig,
+    FeesConfig,
+    OverlayHourlyConfig,
+    RiskConfig,
+)
+from .orchestrator import MultiTimeframeOrchestrator
+
+__all__ = [
+    "BoosterDailyConfig",
+    "FeesConfig",
+    "OverlayHourlyConfig",
+    "RiskConfig",
+    "MultiTimeframeOrchestrator",
+]

--- a/ai_trader_strats/booster_daily.py
+++ b/ai_trader_strats/booster_daily.py
@@ -1,0 +1,172 @@
+"""Daily trend booster strategy implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import logging
+
+import backtrader as bt
+
+from .config_schemas import BoosterDailyConfig
+from .risk_hooks import RiskEngineAdapter
+from .sizing import rebalance_to_notional
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PreviousDonchianHigh(bt.Indicator):
+    """Donchian channel high that ignores the current bar."""
+
+    lines = ("donch",)
+    params = (("period", 55),)
+
+    def __init__(self):
+        super().__init__()
+        self.addminperiod(self.p.period + 1)
+
+    def next(self) -> None:  # type: ignore[override]
+        window = list(self.data.get(size=self.p.period + 1))
+        if len(window) <= 1:
+            self.lines.donch[0] = float("nan")
+            return
+        # Exclude current bar (last element)
+        self.lines.donch[0] = max(window[:-1])
+
+
+@dataclass(slots=True)
+class StrategyMetrics:
+    trades: int = 0
+    fees_paid: float = 0.0
+    equity_peak: float = 0.0
+    max_drawdown: float = 0.0
+    position_sum: float = 0.0
+    bars: int = 0
+
+    def update_equity(self, equity: float) -> None:
+        if equity > self.equity_peak:
+            self.equity_peak = equity
+        if self.equity_peak > 0:
+            drawdown = 1.0 - equity / self.equity_peak
+            self.max_drawdown = max(self.max_drawdown, drawdown)
+
+    def track_position(self, position_notional: float) -> None:
+        self.position_sum += position_notional
+        self.bars += 1
+
+    @property
+    def average_position(self) -> float:
+        return self.position_sum / self.bars if self.bars else 0.0
+
+
+class DailyTrendBooster(bt.Strategy):
+    """Daily trend strategy that boosts exposure in strong markets."""
+
+    params = dict(
+        sma_len=200,
+        don_len=55,
+        strong=1.3,
+        weak=0.3,
+        max_lev=1.5,
+        fees_bps=5,
+        config=None,
+        context=None,
+        risk=None,
+    )
+
+    def __init__(self, *args, **kwargs):  # type: ignore[override]
+        super().__init__(*args, **kwargs)
+        cfg: BoosterDailyConfig | None = self.p.config
+        if cfg is None:
+            cfg = BoosterDailyConfig()
+        self.config = cfg
+        if self.p.context is None:
+            raise ValueError("DailyTrendBooster requires a shared context")
+        self.context = self.p.context
+        self.risk: RiskEngineAdapter = self.p.risk or RiskEngineAdapter(self.broker, cfg.risk)
+
+        # Override parameter defaults with configuration values
+        self.p.sma_len = cfg.filters_sma_len
+        self.p.don_len = cfg.filters_donchian_len
+        self.p.strong = cfg.pos_strong
+        self.p.weak = cfg.pos_weak
+        self.p.max_lev = cfg.max_leverage
+        self.p.fees_bps = cfg.fees.fees_bps_per_side
+
+        self.sma = bt.indicators.SimpleMovingAverage(self.data.close, period=self.p.sma_len)
+        self.donch = PreviousDonchianHigh(self.data.high, period=self.p.don_len)
+
+        self.metrics = StrategyMetrics()
+        self._last_target_notional: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Backtrader hooks
+    # ------------------------------------------------------------------
+    def log(self, msg: str, *args) -> None:
+        _LOGGER.info("[DailyTrendBooster] " + msg, *args)
+
+    def notify_order(self, order) -> None:  # type: ignore[override]
+        if order.status not in (order.Completed, order.Partial):
+            return
+        self.metrics.trades += 1
+        self.metrics.fees_paid += float(getattr(order.executed, "comm", 0.0))
+        self.risk.on_fill(order)
+        _LOGGER.debug(
+            "Order filled: size=%.4f price=%.2f commission=%.4f",
+            order.executed.size,
+            order.executed.price,
+            order.executed.comm,
+        )
+
+    def next(self) -> None:  # type: ignore[override]
+        dt: datetime = self.data.datetime.datetime(0)
+        self.risk.update_clock(dt)
+
+        equity = float(self.broker.getvalue())
+        self.metrics.update_equity(equity)
+
+        price = float(self.data.close[0])
+        position = self.getposition(self.data)
+        notional = (position.size * price) / equity if equity else 0.0
+        self.metrics.track_position(notional)
+
+        if self.risk.locked():
+            if abs(position.size) > 1e-8:
+                _LOGGER.info("Risk lock active; flattening position")
+                rebalance_to_notional(self, 0.0, self.p.fees_bps)
+            if self.context is not None:
+                self.context.update_core("flat", 0.0)
+            self._last_target_notional = 0.0
+            return
+
+        strong_signal = False
+        if len(self.data) >= max(self.p.sma_len, self.p.don_len) + 1:
+            strong_signal = bool(price > float(self.sma[0]) and price > float(self.donch[0]))
+
+        target = self.p.strong if strong_signal else self.p.weak
+        target = min(target, self.p.max_lev)
+        target = self.risk.enforce_caps(target)
+
+        order = rebalance_to_notional(self, target, self.p.fees_bps)
+        if order is not None:
+            _LOGGER.info(
+                "Rebalancing towards %.2fx (signal=%s)",
+                target,
+                "strong" if strong_signal else "weak",
+            )
+        self._last_target_notional = target
+        if self.context is not None:
+            state = "strong" if strong_signal else "weak"
+            self.context.update_core(state, target)
+
+    def stop(self) -> None:  # type: ignore[override]
+        avg_pos = self.metrics.average_position
+        self.log(
+            "Trades=%d fees=%.4f maxDD=%.2f%% avg_notional=%.3f",
+            self.metrics.trades,
+            self.metrics.fees_paid,
+            self.metrics.max_drawdown * 100.0,
+            avg_pos,
+        )
+
+
+__all__ = ["DailyTrendBooster"]

--- a/ai_trader_strats/config_schemas.py
+++ b/ai_trader_strats/config_schemas.py
@@ -1,0 +1,109 @@
+"""Configuration schemas for the AI trader strategies."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Type, TypeVar, get_type_hints
+
+T = TypeVar("T", bound="_ConfigBase")
+
+
+@dataclass(slots=True)
+class _ConfigBase:
+    """Base class for simple dataclass driven configuration objects."""
+
+    @classmethod
+    def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
+        """Create an instance from a dictionary, recursively instantiating nested configs."""
+
+        field_values: Dict[str, Any] = {}
+        type_hints = get_type_hints(cls)
+        for field_name, field_def in cls.__dataclass_fields__.items():  # type: ignore[attr-defined]
+            if field_name not in data:
+                continue
+            value = data[field_name]
+            field_type = type_hints.get(field_name, field_def.type)
+            if isinstance(value, dict) and hasattr(field_type, "from_dict"):
+                field_values[field_name] = field_type.from_dict(value)  # type: ignore[arg-type]
+            else:
+                field_values[field_name] = value
+        return cls(**field_values)  # type: ignore[arg-type]
+
+    @classmethod
+    def from_json(cls: Type[T], path: Path | str) -> T:
+        """Load configuration from a JSON file."""
+
+        import json
+
+        with Path(path).open("r", encoding="utf-8") as handle:
+            payload: Dict[str, Any] = json.load(handle)
+        return cls.from_dict(payload)
+
+
+@dataclass(slots=True)
+class RiskConfig(_ConfigBase):
+    """Risk constraints mirroring the centralized risk engine configuration."""
+
+    dd_lock_pct: float = -0.095
+    daily_loss_lock_pct: float = -0.02
+    single_asset_cap_pct: float = 0.25
+    gross_cap_pct: float = 1.5
+
+
+@dataclass(slots=True)
+class FeesConfig(_ConfigBase):
+    """Trading fee configuration expressed in basis points per side."""
+
+    fees_bps_per_side: int = 5
+
+    @property
+    def commission(self) -> float:
+        """Return the per-side commission in decimal form."""
+
+        return self.fees_bps_per_side / 10000.0
+
+
+@dataclass(slots=True)
+class BoosterDailyConfig(_ConfigBase):
+    """Configuration for the daily trend booster core strategy."""
+
+    name: str = "btc_eur_daily_trend_booster"
+    symbol: str = "BTC/EUR"
+    bar_interval: str = "1d"
+    filters_sma_len: int = 200
+    filters_donchian_len: int = 55
+    pos_strong: float = 1.3
+    pos_weak: float = 0.3
+    max_leverage: float = 1.5
+    fees: FeesConfig = field(default_factory=FeesConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)
+
+
+@dataclass(slots=True)
+class OverlayHourlyConfig(_ConfigBase):
+    """Configuration for the hourly overlay strategy."""
+
+    name: str = "btc_eur_hourly_overlay"
+    symbol: str = "BTC/EUR"
+    bar_interval: str = "1h"
+    ema_fast: int = 8
+    ema_slow: int = 34
+    donchian_high: int = 10
+    overlay_notional: float = 0.2
+    max_total_leverage: float = 1.5
+    fees: FeesConfig = field(default_factory=FeesConfig)
+
+
+def load_config(path: Path | str, cls: Type[T]) -> T:
+    """Load any of the configuration dataclasses from JSON."""
+
+    return cls.from_json(path)
+
+
+__all__ = [
+    "RiskConfig",
+    "FeesConfig",
+    "BoosterDailyConfig",
+    "OverlayHourlyConfig",
+    "load_config",
+]

--- a/ai_trader_strats/configs/btc_eur_daily_trend_booster.json
+++ b/ai_trader_strats/configs/btc_eur_daily_trend_booster.json
@@ -1,0 +1,17 @@
+{
+  "name": "btc_eur_daily_trend_booster",
+  "symbol": "BTC/EUR",
+  "bar_interval": "1d",
+  "filters_sma_len": 200,
+  "filters_donchian_len": 55,
+  "pos_strong": 1.3,
+  "pos_weak": 0.3,
+  "max_leverage": 1.5,
+  "fees": { "fees_bps_per_side": 5 },
+  "risk": {
+    "dd_lock_pct": -0.095,
+    "daily_loss_lock_pct": -0.02,
+    "single_asset_cap_pct": 0.25,
+    "gross_cap_pct": 1.5
+  }
+}

--- a/ai_trader_strats/configs/btc_eur_hourly_overlay.json
+++ b/ai_trader_strats/configs/btc_eur_hourly_overlay.json
@@ -1,0 +1,11 @@
+{
+  "name": "btc_eur_hourly_overlay",
+  "symbol": "BTC/EUR",
+  "bar_interval": "1h",
+  "ema_fast": 8,
+  "ema_slow": 34,
+  "donchian_high": 10,
+  "overlay_notional": 0.2,
+  "max_total_leverage": 1.5,
+  "fees": { "fees_bps_per_side": 5 }
+}

--- a/ai_trader_strats/orchestrator.py
+++ b/ai_trader_strats/orchestrator.py
@@ -1,0 +1,169 @@
+"""Orchestration helpers for running the multi-timeframe strategy stack."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Literal, Optional
+
+import backtrader as bt
+import pandas as pd
+
+from .booster_daily import DailyTrendBooster
+from .config_schemas import BoosterDailyConfig, OverlayHourlyConfig, load_config
+from .overlay_hourly import HourlyTrendOverlay
+from .risk_hooks import RiskEngineAdapter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _DailyPandasData(bt.feeds.PandasData):
+    params = (("timeframe", bt.TimeFrame.Days), ("compression", 1))
+
+
+class _HourlyPandasData(bt.feeds.PandasData):
+    params = (("timeframe", bt.TimeFrame.Minutes), ("compression", 60))
+
+
+@dataclass(slots=True)
+class Context:
+    """Shared context between strategies."""
+
+    core_state: Literal["strong", "weak", "flat"] = "flat"
+    _core_notional: float = 0.0
+    _overlay_notional: float = 0.0
+
+    def daily_is_strong(self) -> bool:
+        return self.core_state == "strong"
+
+    def core_notional(self) -> float:
+        return self._core_notional
+
+    def overlay_notional(self) -> float:
+        return self._overlay_notional
+
+    def update_core(self, state: Literal["strong", "weak", "flat"], notional: float) -> None:
+        self.core_state = state
+        self._core_notional = notional
+
+    def update_overlay(self, notional: float) -> None:
+        self._overlay_notional = notional
+
+
+class MultiTimeframeOrchestrator:
+    """Coordinate the daily booster and hourly overlay strategies."""
+
+    def __init__(
+        self,
+        config_daily: str | Path,
+        config_hourly: str | Path | None = None,
+        broker: str = "paper",
+    ) -> None:
+        self.daily_config = load_config(config_daily, BoosterDailyConfig)
+        self.hourly_config = (
+            load_config(config_hourly, OverlayHourlyConfig) if config_hourly else None
+        )
+        self.broker_mode = broker
+        self._last_run: List[bt.Strategy] = []
+
+    # ------------------------------------------------------------------
+    # Data management
+    # ------------------------------------------------------------------
+    def _load_dataframe(self, path: str | Path) -> pd.DataFrame:
+        df = pd.read_csv(path)
+        rename_map = {col.lower(): col for col in df.columns}
+        required = {"timestamp", "open", "high", "low", "close", "volume"}
+        lower_cols = {col.lower() for col in df.columns}
+        missing = required - lower_cols
+        if missing:
+            raise ValueError(f"CSV missing required columns: {missing}")
+        df = df.rename(columns={rename_map[k]: k for k in required})
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        df = df.sort_values("timestamp")
+        df = df.set_index("timestamp")
+        df.index = df.index.tz_convert("UTC")
+        ordered = df[["open", "high", "low", "close", "volume"]].copy()
+        ordered.columns = [col.capitalize() for col in ordered.columns]
+        return ordered
+
+    def _build_data_feed(self, df: pd.DataFrame, interval: str) -> bt.feeds.PandasData:
+        if interval == "1d":
+            return _DailyPandasData(dataname=df)
+        if interval == "1h":
+            return _HourlyPandasData(dataname=df)
+        raise ValueError(f"Unsupported interval: {interval}")
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+    def run(
+        self,
+        data_daily: str | Path,
+        data_hourly: str | Path | None = None,
+        *,
+        cash: float = 1_000_000.0,
+    ) -> bt.Cerebro:
+        cerebro = bt.Cerebro()
+        cerebro.broker.setcash(cash)
+        cerebro.broker.setcommission(self.daily_config.fees.commission)
+        context = Context()
+        risk = RiskEngineAdapter(cerebro.getbroker(), self.daily_config.risk)
+
+        daily_df = self._load_dataframe(data_daily)
+        cerebro.adddata(self._build_data_feed(daily_df, self.daily_config.bar_interval), name="daily")
+
+        if self.hourly_config and data_hourly:
+            hourly_df = self._load_dataframe(data_hourly)
+            cerebro.adddata(
+                self._build_data_feed(hourly_df, self.hourly_config.bar_interval), name="hourly"
+            )
+
+        cerebro.addstrategy(
+            DailyTrendBooster,
+            config=self.daily_config,
+            context=context,
+            risk=risk,
+        )
+
+        if self.hourly_config and data_hourly:
+            cerebro.addstrategy(
+                HourlyTrendOverlay,
+                config=self.hourly_config,
+                context=context,
+                risk=risk,
+            )
+
+        _LOGGER.info("Starting backtest broker=%s cash=%.2f", self.broker_mode, cash)
+        self._last_run = cerebro.run()
+        return cerebro
+
+    @property
+    def last_run_strategies(self) -> List[bt.Strategy]:
+        return list(self._last_run)
+
+
+def _parse_args(argv: Optional[Iterable[str]] = None):
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the AI trader strategy stack")
+    parser.add_argument("--config-daily", required=True)
+    parser.add_argument("--data-daily", required=True)
+    parser.add_argument("--config-hourly")
+    parser.add_argument("--data-hourly")
+    parser.add_argument("--broker", default="paper")
+    parser.add_argument("--cash", type=float, default=1_000_000.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = _parse_args(argv)
+    orchestrator = MultiTimeframeOrchestrator(
+        config_daily=args.config_daily,
+        config_hourly=args.config_hourly,
+        broker=args.broker,
+    )
+    orchestrator.run(data_daily=args.data_daily, data_hourly=args.data_hourly, cash=args.cash)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_trader_strats/overlay_hourly.py
+++ b/ai_trader_strats/overlay_hourly.py
@@ -1,0 +1,155 @@
+"""Hourly overlay strategy that adds exposure during strong trends."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import logging
+
+import backtrader as bt
+
+from .booster_daily import PreviousDonchianHigh
+from .config_schemas import OverlayHourlyConfig
+from .risk_hooks import RiskEngineAdapter
+from .sizing import rebalance_to_notional
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class OverlayMetrics:
+    trades: int = 0
+    fees_paid: float = 0.0
+    equity_peak: float = 0.0
+    max_drawdown: float = 0.0
+    position_sum: float = 0.0
+    bars: int = 0
+
+    def update_equity(self, equity: float) -> None:
+        if equity > self.equity_peak:
+            self.equity_peak = equity
+        if self.equity_peak > 0:
+            drawdown = 1.0 - equity / self.equity_peak
+            self.max_drawdown = max(self.max_drawdown, drawdown)
+
+    def track_position(self, notional: float) -> None:
+        self.position_sum += notional
+        self.bars += 1
+
+    @property
+    def average_position(self) -> float:
+        return self.position_sum / self.bars if self.bars else 0.0
+
+
+class HourlyTrendOverlay(bt.Strategy):
+    """Hourly momentum overlay to piggyback on the daily core signal."""
+
+    params = dict(
+        ema_fast=8,
+        ema_slow=34,
+        don=10,
+        overlay=0.2,
+        max_total=1.5,
+        fees_bps=5,
+        config=None,
+        context=None,
+        risk=None,
+    )
+
+    def __init__(self, *args, **kwargs):  # type: ignore[override]
+        super().__init__(*args, **kwargs)
+        cfg: OverlayHourlyConfig | None = self.p.config
+        if cfg is None:
+            cfg = OverlayHourlyConfig()
+        self.config = cfg
+        if self.p.context is None:
+            raise ValueError("HourlyTrendOverlay requires a shared context")
+        self.context = self.p.context
+        if self.p.risk is None:
+            raise ValueError("HourlyTrendOverlay requires a shared RiskEngineAdapter")
+        self.risk: RiskEngineAdapter = self.p.risk
+
+        self.p.ema_fast = cfg.ema_fast
+        self.p.ema_slow = cfg.ema_slow
+        self.p.don = cfg.donchian_high
+        self.p.overlay = cfg.overlay_notional
+        self.p.max_total = cfg.max_total_leverage
+        self.p.fees_bps = cfg.fees.fees_bps_per_side
+
+        self.fast = bt.indicators.ExponentialMovingAverage(self.data.close, period=self.p.ema_fast)
+        self.slow = bt.indicators.ExponentialMovingAverage(self.data.close, period=self.p.ema_slow)
+        self.donch = PreviousDonchianHigh(self.data.high, period=self.p.don)
+
+        self.metrics = OverlayMetrics()
+        self._last_target: float = 0.0
+
+    def notify_order(self, order) -> None:  # type: ignore[override]
+        if order.status not in (order.Completed, order.Partial):
+            return
+        self.metrics.trades += 1
+        self.metrics.fees_paid += float(getattr(order.executed, "comm", 0.0))
+        self.risk.on_fill(order)
+        _LOGGER.debug(
+            "Overlay fill: size=%.4f price=%.2f comm=%.4f",
+            order.executed.size,
+            order.executed.price,
+            order.executed.comm,
+        )
+
+    def next(self) -> None:  # type: ignore[override]
+        dt: datetime = self.data.datetime.datetime(0)
+        self.risk.update_clock(dt)
+        equity = float(self.broker.getvalue())
+        self.metrics.update_equity(equity)
+
+        price = float(self.data.close[0])
+        position = self.getposition(self.data)
+        notional = (position.size * price) / equity if equity else 0.0
+        self.metrics.track_position(notional)
+
+        if self.risk.locked():
+            if abs(position.size) > 1e-8:
+                _LOGGER.info("Risk lock active; overlay flattening")
+                rebalance_to_notional(self, 0.0, self.p.fees_bps)
+            if self.context is not None:
+                self.context.update_overlay(0.0)
+            self._last_target = 0.0
+            return
+
+        overlay_allowed = bool(self.context and self.context.daily_is_strong())
+        overlay_signal = False
+        if overlay_allowed and len(self.data) >= max(self.p.ema_fast, self.p.ema_slow, self.p.don) + 1:
+            overlay_signal = bool(
+                float(self.fast[0]) > float(self.slow[0]) and price > float(self.donch[0])
+            )
+
+        base_notional = self.context.core_notional() if self.context else 0.0
+        target = base_notional
+        if overlay_allowed and overlay_signal:
+            additional = min(self.p.overlay, max(0.0, self.p.max_total - base_notional))
+            target = base_notional + additional
+        target = min(target, self.p.max_total)
+        target = self.risk.enforce_caps(target)
+
+        order = rebalance_to_notional(self, target, self.p.fees_bps)
+        if order is not None:
+            _LOGGER.info(
+                "Overlay targeting %.2fx (base=%.2f overlay=%.2f)",
+                target,
+                base_notional,
+                target - base_notional,
+            )
+        self._last_target = target
+        if self.context is not None:
+            self.context.update_overlay(max(0.0, target - base_notional))
+
+    def stop(self) -> None:  # type: ignore[override]
+        _LOGGER.info(
+            "[HourlyOverlay] Trades=%d fees=%.4f maxDD=%.2f%% avg_notional=%.3f",
+            self.metrics.trades,
+            self.metrics.fees_paid,
+            self.metrics.max_drawdown * 100.0,
+            self.metrics.average_position,
+        )
+
+
+__all__ = ["HourlyTrendOverlay"]

--- a/ai_trader_strats/risk_hooks.py
+++ b/ai_trader_strats/risk_hooks.py
@@ -1,0 +1,155 @@
+"""Adapters to bridge strategy logic with the platform risk engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+import logging
+from typing import Optional
+
+from .config_schemas import RiskConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _RiskState:
+    """Internal bookkeeping for risk locks."""
+
+    equity_hwm: float
+    day_start_equity: float
+    day: date
+    drawdown_lock: bool = False
+    daily_lock: bool = False
+    last_timestamp: Optional[datetime] = None
+
+
+class RiskEngineAdapter:
+    """Minimal adapter enforcing drawdown and daily loss locks."""
+
+    def __init__(self, broker, risk_cfg: RiskConfig):
+        self._broker = broker
+        self._cfg = risk_cfg
+        initial_equity = float(getattr(self._broker, "getvalue", lambda: 0.0)())
+        today = datetime.utcnow().date()
+        self._state = _RiskState(
+            equity_hwm=initial_equity,
+            day_start_equity=initial_equity,
+            day=today,
+        )
+        self._lock_reason: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def update_clock(self, timestamp: datetime) -> None:
+        """Update the internal clock to support daily lock resets."""
+
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        self._state.last_timestamp = timestamp.astimezone(timezone.utc)
+
+    def locked(self) -> bool:
+        """Return ``True`` when drawdown or daily loss locks are engaged."""
+
+        self._refresh_state()
+        return self._state.drawdown_lock or self._state.daily_lock
+
+    def enforce_caps(self, target_notional: float) -> float:
+        """Clamp exposure requests to the configured caps."""
+
+        if self.locked():
+            return 0.0
+        cap = min(abs(self._cfg.single_asset_cap_pct), abs(self._cfg.gross_cap_pct))
+        if cap <= 0:
+            return 0.0
+        adjusted = max(-cap, min(cap, target_notional))
+        if adjusted != target_notional:
+            _LOGGER.debug(
+                "Risk caps reduced notional from %.4f to %.4f", target_notional, adjusted
+            )
+        return adjusted
+
+    def on_fill(self, order) -> None:
+        """Update state upon order execution."""
+
+        executed = getattr(order, "executed", None)
+        if executed is not None and getattr(executed, "dt", None) is not None:
+            try:
+                from backtrader.utils.date import num2date
+
+                dt = num2date(executed.dt)
+                if isinstance(dt, datetime):
+                    self.update_clock(dt)
+            except Exception:  # pragma: no cover - defensive
+                _LOGGER.debug("Failed to parse order execution timestamp", exc_info=True)
+        self._refresh_state()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _refresh_state(self) -> None:
+        equity = float(getattr(self._broker, "getvalue", lambda: 0.0)())
+        current_dt = self._current_day()
+
+        previous_hwm = self._state.equity_hwm
+        if equity > previous_hwm:
+            self._state.equity_hwm = equity
+            if self._state.drawdown_lock:
+                _LOGGER.info(
+                    "Drawdown lock released after equity recovered to high water mark"
+                )
+                self._state.drawdown_lock = False
+                if self._lock_reason == "drawdown":
+                    self._lock_reason = None
+
+        drawdown_pct = (equity / self._state.equity_hwm - 1.0) if self._state.equity_hwm else 0.0
+        if drawdown_pct <= self._cfg.dd_lock_pct:
+            if not self._state.drawdown_lock:
+                _LOGGER.warning(
+                    "Drawdown lock engaged at %.2f%%", drawdown_pct * 100.0
+                )
+            self._state.drawdown_lock = True
+            self._lock_reason = "drawdown"
+
+        if current_dt != self._state.day:
+            self._state.day = current_dt
+            self._state.day_start_equity = equity
+            if self._state.daily_lock:
+                _LOGGER.info("Daily loss lock reset for new trading day")
+            self._state.daily_lock = False
+            if self._lock_reason == "daily":
+                self._lock_reason = None
+
+        if self._state.day_start_equity == 0:
+            daily_change = 0.0
+        else:
+            daily_change = equity / self._state.day_start_equity - 1.0
+        if daily_change <= self._cfg.daily_loss_lock_pct:
+            if not self._state.daily_lock:
+                _LOGGER.warning(
+                    "Daily loss lock engaged at %.2f%%", daily_change * 100.0
+                )
+            self._state.daily_lock = True
+            self._lock_reason = "daily"
+        elif not self._state.drawdown_lock:
+            self._lock_reason = None
+
+    def _current_day(self) -> date:
+        timestamp = self._state.last_timestamp
+        if timestamp is None:
+            return datetime.utcnow().date()
+        return timestamp.astimezone(timezone.utc).date()
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+    @property
+    def lock_reason(self) -> Optional[str]:
+        """Return the active lock reason if any."""
+
+        if not self.locked():
+            return None
+        return self._lock_reason
+
+
+__all__ = ["RiskEngineAdapter"]

--- a/ai_trader_strats/sizing.py
+++ b/ai_trader_strats/sizing.py
@@ -1,0 +1,67 @@
+"""Position sizing helpers shared across strategies."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import backtrader as bt
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def rebalance_to_notional(
+    strategy: bt.Strategy, target_notional: float, fees_bps: int
+) -> Optional[bt.Order]:
+    """Rebalance the instrument to the desired notional exposure.
+
+    Parameters
+    ----------
+    strategy:
+        Strategy issuing the rebalance.
+    target_notional:
+        Desired notional exposure expressed as a multiple of account equity.
+    fees_bps:
+        Trading fee in basis points per side.
+
+    Returns
+    -------
+    Optional[bt.Order]
+        The generated order, ``None`` when no trade is required.
+    """
+
+    data = strategy.data0
+    price = float(data.close[0])
+    equity = float(strategy.broker.getvalue())
+    if equity <= 0 or price <= 0:
+        _LOGGER.debug("Skipping rebalance due to non-positive equity=%.4f price=%.4f", equity, price)
+        return None
+
+    position = strategy.getposition(data)
+    current_size = float(getattr(position, "size", 0.0))
+    current_value = current_size * price
+    current_notional = current_value / equity if equity else 0.0
+    if abs(target_notional - current_notional) < 1e-4:
+        return None
+
+    target_value = target_notional * equity
+    target_size = target_value / price
+    delta_size = target_size - current_size
+    if abs(delta_size) * price < 1e-6:
+        return None
+
+    fees_fraction = fees_bps / 10000.0
+    if delta_size > 0:
+        target_size = current_size + delta_size * (1.0 + fees_fraction)
+    else:
+        target_size = current_size + delta_size * (1.0 + fees_fraction)
+    _LOGGER.debug(
+        "Rebalance request: current_notional=%.4f target=%.4f delta_size=%.4f",
+        current_notional,
+        target_notional,
+        delta_size,
+    )
+    order = strategy.order_target_size(data=data, target=target_size)
+    return order
+
+
+__all__ = ["rebalance_to_notional"]

--- a/ai_trader_strats/tests/__init__.py
+++ b/ai_trader_strats/tests/__init__.py
@@ -1,0 +1,9 @@
+"""Test suite bootstrap for ai_trader_strats."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/ai_trader_strats/tests/test_configs.py
+++ b/ai_trader_strats/tests/test_configs.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from ai_trader_strats.config_schemas import BoosterDailyConfig, OverlayHourlyConfig
+
+
+def test_daily_config_ranges():
+    root = Path(__file__).resolve().parents[1]
+    cfg = BoosterDailyConfig.from_json(root / "configs" / "btc_eur_daily_trend_booster.json")
+    assert 0.0 <= cfg.pos_weak < cfg.pos_strong <= cfg.max_leverage <= 2.0
+
+
+def test_hourly_config_loads():
+    root = Path(__file__).resolve().parents[1]
+    cfg = OverlayHourlyConfig.from_json(root / "configs" / "btc_eur_hourly_overlay.json")
+    assert cfg.overlay_notional > 0
+    assert cfg.ema_fast < cfg.ema_slow

--- a/ai_trader_strats/tests/test_integration_orchestrator.py
+++ b/ai_trader_strats/tests/test_integration_orchestrator.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ai_trader_strats.booster_daily import DailyTrendBooster
+from ai_trader_strats.overlay_hourly import HourlyTrendOverlay
+from ai_trader_strats.orchestrator import MultiTimeframeOrchestrator
+
+
+def _write_csv(path: Path, df: pd.DataFrame) -> None:
+    df.to_csv(path, index=False)
+
+
+def test_orchestrator_integration(tmp_path: Path):
+    daily_dates = pd.date_range("2022-01-01", periods=260, freq="D", tz="UTC")
+    daily_prices = np.concatenate([
+        np.linspace(100, 180, 220),
+        np.linspace(180, 60, 40),
+    ])
+    daily_df = pd.DataFrame(
+        {
+            "Timestamp": daily_dates,
+            "Open": daily_prices,
+            "High": daily_prices * 1.01,
+            "Low": daily_prices * 0.99,
+            "Close": daily_prices,
+            "Volume": np.full_like(daily_prices, 10.0),
+        }
+    )
+    hourly_dates = pd.date_range(daily_dates[0], periods=260 * 24, freq="h", tz="UTC")
+    hourly_prices = np.linspace(100, 60, len(hourly_dates))
+    hourly_df = pd.DataFrame(
+        {
+            "Timestamp": hourly_dates,
+            "Open": hourly_prices,
+            "High": hourly_prices * 1.005,
+            "Low": hourly_prices * 0.995,
+            "Close": hourly_prices,
+            "Volume": np.full_like(hourly_prices, 5.0),
+        }
+    )
+
+    daily_path = tmp_path / "daily.csv"
+    hourly_path = tmp_path / "hourly.csv"
+    _write_csv(daily_path, daily_df)
+    _write_csv(hourly_path, hourly_df)
+
+    root = Path(__file__).resolve().parents[1]
+    orchestrator = MultiTimeframeOrchestrator(
+        config_daily=root / "configs" / "btc_eur_daily_trend_booster.json",
+        config_hourly=root / "configs" / "btc_eur_hourly_overlay.json",
+    )
+    cerebro = orchestrator.run(data_daily=daily_path, data_hourly=hourly_path, cash=250_000)
+
+    strategies = orchestrator.last_run_strategies
+    assert any(isinstance(s, DailyTrendBooster) for s in strategies)
+    assert any(isinstance(s, HourlyTrendOverlay) for s in strategies)
+
+    for strat in strategies:
+        if isinstance(strat, DailyTrendBooster):
+            assert abs(strat._last_target_notional) <= strat.config.max_leverage + 1e-6
+            assert strat.metrics.max_drawdown >= 0.095
+            assert abs(strat._last_target_notional) <= strat.config.risk.single_asset_cap_pct + 1e-6
+            assert strat.risk.enforce_caps(strat.config.max_leverage) <= strat.config.risk.single_asset_cap_pct
+        if isinstance(strat, HourlyTrendOverlay):
+            assert strat._last_target <= strat.config.max_total_leverage + 1e-6
+            assert strat.context.overlay_notional() == pytest.approx(0.0)

--- a/ai_trader_strats/tests/test_risk_engine_hooks.py
+++ b/ai_trader_strats/tests/test_risk_engine_hooks.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from ai_trader_strats.config_schemas import RiskConfig
+from ai_trader_strats.risk_hooks import RiskEngineAdapter
+
+
+class BrokerStub:
+    def __init__(self, value: float = 100.0):
+        self._value = value
+
+    def getvalue(self) -> float:
+        return self._value
+
+    def setvalue(self, value: float) -> None:
+        self._value = value
+
+
+@pytest.fixture
+def daily_lock_adapter() -> tuple[RiskEngineAdapter, BrokerStub]:
+    broker = BrokerStub()
+    cfg = RiskConfig(dd_lock_pct=-0.095, daily_loss_lock_pct=-0.02, single_asset_cap_pct=5.0, gross_cap_pct=5.0)
+    adapter = RiskEngineAdapter(broker, cfg)
+    adapter.update_clock(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    return adapter, broker
+
+
+def test_drawdown_lock():
+    broker = BrokerStub()
+    cfg = RiskConfig(dd_lock_pct=-0.095, daily_loss_lock_pct=-0.5, single_asset_cap_pct=5.0, gross_cap_pct=5.0)
+    adapter = RiskEngineAdapter(broker, cfg)
+    adapter.update_clock(datetime(2024, 1, 1, tzinfo=timezone.utc))
+    assert not adapter.locked()
+    broker.setvalue(89.0)
+    assert adapter.locked()
+    broker.setvalue(95.0)
+    assert adapter.locked()
+    broker.setvalue(105.0)
+    assert not adapter.locked()
+
+
+def test_daily_lock_reset(daily_lock_adapter: tuple[RiskEngineAdapter, BrokerStub]):
+    adapter, broker = daily_lock_adapter
+    adapter.locked()  # prime state
+    broker.setvalue(97.0)
+    adapter.update_clock(datetime(2024, 1, 1, 12, tzinfo=timezone.utc))
+    assert adapter.locked()
+    adapter.update_clock(datetime(2024, 1, 2, tzinfo=timezone.utc))
+    broker.setvalue(101.0)
+    assert not adapter.locked()

--- a/ai_trader_strats/tests/test_signals_daily.py
+++ b/ai_trader_strats/tests/test_signals_daily.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+import pytest
+import backtrader as bt
+
+from ai_trader_strats.booster_daily import DailyTrendBooster
+from ai_trader_strats.config_schemas import BoosterDailyConfig, FeesConfig, RiskConfig
+from ai_trader_strats.orchestrator import Context
+from ai_trader_strats.risk_hooks import RiskEngineAdapter
+
+
+def _run_daily_strategy(prices: np.ndarray) -> DailyTrendBooster:
+    dates = pd.date_range("2022-01-01", periods=len(prices), freq="D", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "Open": prices,
+            "High": prices,
+            "Low": prices * 0.999,
+            "Close": prices,
+            "Volume": np.full_like(prices, 1.0),
+        },
+        index=dates,
+    )
+    cfg = BoosterDailyConfig(
+        filters_sma_len=10,
+        filters_donchian_len=10,
+        pos_strong=1.3,
+        pos_weak=0.3,
+        max_leverage=1.5,
+        fees=FeesConfig(fees_bps_per_side=0),
+        risk=RiskConfig(dd_lock_pct=-0.2, daily_loss_lock_pct=-0.2, single_asset_cap_pct=5.0, gross_cap_pct=5.0),
+    )
+    cerebro = bt.Cerebro()
+    cerebro.broker.setcash(100_000)
+    cerebro.broker.setcommission(0.0)
+    cerebro.adddata(bt.feeds.PandasData(dataname=df))
+    context = Context()
+    risk = RiskEngineAdapter(cerebro.getbroker(), cfg.risk)
+    cerebro.addstrategy(DailyTrendBooster, config=cfg, context=context, risk=risk)
+    strategies = cerebro.run()
+    return strategies[0]
+
+
+def test_daily_strong_signal_targets_boost():
+    prices = np.linspace(10, 30, 220)
+    strat = _run_daily_strategy(prices)
+    assert strat._last_target_notional == pytest.approx(1.3)
+    assert strat.context.daily_is_strong()
+
+
+def test_daily_weak_signal_targets_low_exposure():
+    prices = np.full(220, 20.0)
+    strat = _run_daily_strategy(prices)
+    assert strat._last_target_notional == pytest.approx(0.3)
+    assert strat.context.core_notional() == pytest.approx(0.3)

--- a/ai_trader_strats/tests/test_signals_hourly.py
+++ b/ai_trader_strats/tests/test_signals_hourly.py
@@ -21,6 +21,11 @@ def _run_overlay_strategy(prices: np.ndarray, context: Context) -> HourlyTrendOv
         },
         index=dates,
     )
+    daily_df = df.resample("1D").last().copy()
+    daily_df["Open"] = daily_df["Close"]
+    daily_df["High"] = daily_df["Close"]
+    daily_df["Low"] = daily_df["Close"]
+    daily_df["Volume"] = 10.0
     cfg = OverlayHourlyConfig(
         ema_fast=4,
         ema_slow=12,
@@ -32,7 +37,8 @@ def _run_overlay_strategy(prices: np.ndarray, context: Context) -> HourlyTrendOv
     cerebro = bt.Cerebro()
     cerebro.broker.setcash(100_000)
     cerebro.broker.setcommission(0.0)
-    cerebro.adddata(bt.feeds.PandasData(dataname=df))
+    cerebro.adddata(bt.feeds.PandasData(dataname=daily_df))
+    cerebro.adddata(bt.feeds.PandasData(dataname=df), name="hourly")
     risk_cfg = RiskConfig(dd_lock_pct=-0.2, daily_loss_lock_pct=-0.2, single_asset_cap_pct=5.0, gross_cap_pct=5.0)
     risk = RiskEngineAdapter(cerebro.getbroker(), risk_cfg)
     cerebro.addstrategy(HourlyTrendOverlay, config=cfg, context=context, risk=risk)

--- a/ai_trader_strats/tests/test_signals_hourly.py
+++ b/ai_trader_strats/tests/test_signals_hourly.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pandas as pd
+import pytest
+import backtrader as bt
+
+from ai_trader_strats.config_schemas import FeesConfig, OverlayHourlyConfig, RiskConfig
+from ai_trader_strats.orchestrator import Context
+from ai_trader_strats.overlay_hourly import HourlyTrendOverlay
+from ai_trader_strats.risk_hooks import RiskEngineAdapter
+
+
+def _run_overlay_strategy(prices: np.ndarray, context: Context) -> HourlyTrendOverlay:
+    dates = pd.date_range("2022-01-01", periods=len(prices), freq="h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "Open": prices,
+            "High": prices,
+            "Low": prices * 0.998,
+            "Close": prices,
+            "Volume": np.full_like(prices, 5.0),
+        },
+        index=dates,
+    )
+    cfg = OverlayHourlyConfig(
+        ema_fast=4,
+        ema_slow=12,
+        donchian_high=6,
+        overlay_notional=0.2,
+        max_total_leverage=1.5,
+        fees=FeesConfig(fees_bps_per_side=0),
+    )
+    cerebro = bt.Cerebro()
+    cerebro.broker.setcash(100_000)
+    cerebro.broker.setcommission(0.0)
+    cerebro.adddata(bt.feeds.PandasData(dataname=df))
+    risk_cfg = RiskConfig(dd_lock_pct=-0.2, daily_loss_lock_pct=-0.2, single_asset_cap_pct=5.0, gross_cap_pct=5.0)
+    risk = RiskEngineAdapter(cerebro.getbroker(), risk_cfg)
+    cerebro.addstrategy(HourlyTrendOverlay, config=cfg, context=context, risk=risk)
+    strategies = cerebro.run()
+    return strategies[0]
+
+
+def test_overlay_engages_when_daily_strong():
+    context = Context()
+    context.update_core("strong", 1.3)
+    prices = np.linspace(20, 40, 400)
+    strat = _run_overlay_strategy(prices, context)
+    assert strat._last_target == pytest.approx(1.5)
+    assert context.overlay_notional() == pytest.approx(0.2)
+
+
+def test_overlay_idle_when_daily_not_strong():
+    context = Context()
+    context.update_core("weak", 0.8)
+    prices = np.linspace(20, 40, 400)
+    strat = _run_overlay_strategy(prices, context)
+    assert strat._last_target == pytest.approx(0.8)
+    assert context.overlay_notional() == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add ai_trader_strats package with configuration schemas, risk adapter, sizing helper, and orchestrator
- implement DailyTrendBooster and HourlyTrendOverlay backtrader strategies with shared context
- provide JSON configs, README, and pytest coverage for configs, risk hooks, signal logic, and orchestrator integration

## Testing
- pytest ai_trader_strats/tests

------
https://chatgpt.com/codex/tasks/task_e_68e596dd58908325af851e605f7d32fd